### PR TITLE
#46 設定画面でアラームの設定を変えられるようにしました

### DIFF
--- a/ReactNative/app/(tabs)/home.tsx
+++ b/ReactNative/app/(tabs)/home.tsx
@@ -1,16 +1,24 @@
 import { View } from "react-native";
-import { useEffect, useState } from "react";
+import { useEffect, useContext } from "react";
 import Button from "@/components/ui/Button";
 import TimeBox from "@/components/ui/TimeBox";
 import { MAINCOLORS } from "@/constants/colors";
 import Title from "@/components/ui/title";
-import { useAlarmMonitor } from "@/hooks/useAlarmMonitor";
+import { AlarmMonitorContext } from "@/contexts/AlarmMonitorContext";
 import { useAlarmAudio } from "@/hooks/useAlarmAudio";
 
 export default function Home() {
-  const [time, setTime] = useState("09:00");
-  const { isMonitoring, isAlarmActive, setIsReset } = useAlarmMonitor(time);
+  const alarmMonitor = useContext(AlarmMonitorContext);
   const { setVolume } = useAlarmAudio();
+
+  if (!alarmMonitor) {
+    throw new Error(
+      "AlarmMonitorContext must be used within AlarmMonitorProvider",
+    );
+  }
+
+  const { isMonitoring, isAlarmActive, reset, setTargetTime, targetTime } =
+    alarmMonitor;
 
   useEffect(() => {
     if (isAlarmActive && isMonitoring) {
@@ -36,13 +44,13 @@ export default function Home() {
       <Title>Home</Title>
       <TimeBox
         onConfirm={(t) => {
-          setTime(t);
+          setTargetTime(t);
         }}
       />
       <Button
         disabled={!isMonitoring}
         onPress={() => {
-          setIsReset(true);
+          reset();
         }}
       >
         stop

--- a/ReactNative/app/(tabs)/settings.tsx
+++ b/ReactNative/app/(tabs)/settings.tsx
@@ -1,12 +1,13 @@
-import { View, Text, Alert, ScrollView } from "react-native";
-import { useState } from "react";
-import { MAINCOLORS } from "@/constants/colors";
+import { View, Text, Alert, ScrollView, Pressable } from "react-native";
+import { useState, useContext } from "react";
+import { MAINCOLORS, FontColors } from "@/constants/colors";
 import Title from "@/components/ui/title";
 import { SettingItem, SettingSection } from "@/components/ui/Setting";
 import { useSerialPort } from "@/hooks/useSerialPort";
 import { useAlarmAudio } from "@/hooks/useAlarmAudio";
 import { useAudioLevel } from "@/hooks/useAudioLevel";
 import { useAccelerometer } from "@/hooks/useAccelerometer";
+import { AlarmMonitorContext } from "@/contexts/AlarmMonitorContext";
 import { fetchAndSaveAlarmData } from "@/services/alarmService";
 import { clearCache } from "@/utils/fileCache";
 import { Link } from "expo-router";
@@ -14,10 +15,25 @@ import { Link } from "expo-router";
 export default function Settings() {
   const volume = useAudioLevel();
   const magnitude = useAccelerometer();
+  const alarmMonitor = useContext(AlarmMonitorContext);
   const { serialState, trySendData } = useSerialPort();
   const { setVolume, loadAudio, isReady, isPlaying, isUsingCachedAudio } =
     useAlarmAudio();
   const [isLoading, setIsLoading] = useState(false);
+
+  if (!alarmMonitor) {
+    throw new Error(
+      "AlarmMonitorContext must be used within AlarmMonitorProvider",
+    );
+  }
+
+  const {
+    threshold,
+    setThreshold,
+    monitoringStartMinutes,
+    setMonitoringStartMinutes,
+  } = alarmMonitor;
+
   // 接続状態を日本語に変換
   const getConnectionStatusText = () => {
     switch (serialState) {
@@ -149,6 +165,124 @@ export default function Settings() {
             </Text>
           </SettingItem>
           <SettingItem title="接続をテスト" onPress={handleConnectionTest} />
+        </SettingSection>
+        <SettingSection title="アラーム設定">
+          <SettingItem title="加速度センサー閾値">
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 3,
+                backgroundColor: MAINCOLORS.border,
+                paddingHorizontal: 4,
+                borderRadius: 8,
+              }}
+            >
+              <Pressable
+                onPress={() => {
+                  setThreshold((prev) => prev - 0.005);
+                }}
+                style={{
+                  paddingHorizontal: 6,
+                }}
+              >
+                <Text
+                  style={{
+                    color: FontColors.maincolors,
+                    fontSize: 20,
+                    fontWeight: "600",
+                  }}
+                >
+                  -
+                </Text>
+              </Pressable>
+              <Text
+                style={{
+                  color: FontColors.maincolors,
+                  fontSize: 16,
+                  fontWeight: "600",
+                }}
+              >
+                {threshold.toFixed(3)}
+              </Text>
+              <Pressable
+                onPress={() => {
+                  setThreshold((prev) => prev + 0.005);
+                }}
+                style={{
+                  paddingHorizontal: 6,
+                }}
+              >
+                <Text
+                  style={{
+                    color: FontColors.maincolors,
+                    fontSize: 20,
+                    fontWeight: "600",
+                  }}
+                >
+                  +
+                </Text>
+              </Pressable>
+            </View>
+          </SettingItem>
+          <SettingItem title="開始時間(分前)">
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 6,
+                backgroundColor: MAINCOLORS.border,
+                paddingHorizontal: 8,
+                borderRadius: 8,
+              }}
+            >
+              <Pressable
+                onPress={() => {
+                  setMonitoringStartMinutes((prev) => prev - 1);
+                }}
+                style={{
+                  paddingHorizontal: 6,
+                }}
+              >
+                <Text
+                  style={{
+                    color: FontColors.maincolors,
+                    fontSize: 20,
+                    fontWeight: "600",
+                  }}
+                >
+                  -
+                </Text>
+              </Pressable>
+              <Text
+                style={{
+                  color: FontColors.maincolors,
+                  fontSize: 16,
+                  fontWeight: "600",
+                }}
+              >
+                {monitoringStartMinutes}分
+              </Text>
+              <Pressable
+                onPress={() => {
+                  setMonitoringStartMinutes((prev) => prev + 1);
+                }}
+                style={{
+                  paddingHorizontal: 6,
+                }}
+              >
+                <Text
+                  style={{
+                    color: FontColors.maincolors,
+                    fontSize: 20,
+                    fontWeight: "600",
+                  }}
+                >
+                  +
+                </Text>
+              </Pressable>
+            </View>
+          </SettingItem>
         </SettingSection>
         <SettingSection title="音声ファイル">
           <SettingItem title="ファイル状況">

--- a/ReactNative/app/_layout.tsx
+++ b/ReactNative/app/_layout.tsx
@@ -2,6 +2,7 @@ import { Stack } from "expo-router";
 import { Platform } from "react-native";
 import Constants, { ExecutionEnvironment } from "expo-constants";
 import { AlarmAudioProvider } from "@/contexts/AlarmAudioContext";
+import { AlarmMonitorProvider } from "@/contexts/AlarmMonitorContext";
 
 const DummySerialPortProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -30,14 +31,18 @@ export default function RootLayout() {
     return (
       <SerialPortProvider>
         <AlarmAudioProvider>
-          <Stack screenOptions={{ headerShown: false }} />
+          <AlarmMonitorProvider>
+            <Stack screenOptions={{ headerShown: false }} />
+          </AlarmMonitorProvider>
         </AlarmAudioProvider>
       </SerialPortProvider>
     );
   } else {
     return (
       <AlarmAudioProvider>
-        <Stack screenOptions={{ headerShown: false }} />
+        <AlarmMonitorProvider>
+          <Stack screenOptions={{ headerShown: false }} />
+        </AlarmMonitorProvider>
       </AlarmAudioProvider>
     );
   }

--- a/ReactNative/components/ui/Setting.tsx
+++ b/ReactNative/components/ui/Setting.tsx
@@ -50,7 +50,7 @@ export function SettingItem({
           flexDirection: "row",
           justifyContent: "space-between",
           alignItems: "center",
-          paddingHorizontal: 12,
+          paddingHorizontal: 6,
           paddingVertical: 6,
           gap: 12,
           borderWidth: 2,

--- a/ReactNative/contexts/AlarmMonitorContext.tsx
+++ b/ReactNative/contexts/AlarmMonitorContext.tsx
@@ -1,0 +1,165 @@
+import React, { createContext, useState, useEffect, useCallback } from "react";
+import { useAccelerometer } from "@/hooks/useAccelerometer";
+
+/**
+ * AlarmMonitorContextの型定義
+ */
+type AlarmMonitorContextType = {
+  /** 監視中かどうか */
+  isMonitoring: boolean;
+  /** アラームが有効かどうか */
+  isAlarmActive: boolean;
+  /** リセットする関数 */
+  reset: () => void;
+  /** 目標時刻を設定する関数 */
+  setTargetTime: (timeStr: string) => void;
+  /** 現在の目標時刻 */
+  targetTime: string;
+  /** 加速度センサーの閾値 */
+  threshold: number;
+  /** 閾値を設定する関数 */
+  setThreshold: (value: number | ((prev: number) => number)) => void;
+  /** 監視開始時間（目標時刻の何分前か） */
+  monitoringStartMinutes: number;
+  /** 監視開始時間を設定する関数 */
+  setMonitoringStartMinutes: (
+    minutes: number | ((prev: number) => number),
+  ) => void;
+};
+
+/**
+ * AlarmMonitorContext
+ */
+export const AlarmMonitorContext =
+  createContext<AlarmMonitorContextType | null>(null);
+
+/**
+ * AlarmMonitorProvider
+ * アラームの監視状態を管理する
+ */
+export const AlarmMonitorProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [targetTime, setTargetTimeState] = useState<string>("09:00");
+  const [isMonitoring, setIsMonitoring] = useState<boolean>(false);
+  const [isAlarmActive, setIsAlarmActive] = useState<boolean>(false);
+  const [isReset, setIsReset] = useState<boolean>(false);
+  const [threshold, setThresholdState] = useState<number>(1.05);
+  const [monitoringStartMinutes, setMonitoringStartMinutesState] =
+    useState<number>(30);
+  const magnitude = useAccelerometer();
+
+  /**
+   * 目標時刻を設定する関数
+   */
+  const setTargetTime = useCallback((timeStr: string) => {
+    setTargetTimeState(timeStr);
+    setIsReset(false);
+  }, []);
+
+  /**
+   * リセットする関数
+   */
+  const reset = useCallback(() => {
+    setIsReset(true);
+  }, []);
+
+  /**
+   * 閾値を設定する関数
+   */
+  const setThreshold = useCallback(
+    (value: number | ((prev: number) => number)) => {
+      setThresholdState((prev) => {
+        const newValue = typeof value === "function" ? value(prev) : value;
+        return Math.max(1.0, Math.min(2.0, newValue));
+      });
+    },
+    [],
+  );
+
+  /**
+   * 監視開始時間を設定する関数
+   */
+  const setMonitoringStartMinutes = useCallback(
+    (minutes: number | ((prev: number) => number)) => {
+      setMonitoringStartMinutesState((prev) => {
+        const newValue =
+          typeof minutes === "function" ? minutes(prev) : minutes;
+        return Math.max(0, Math.min(120, newValue));
+      });
+    },
+    [],
+  );
+
+  /**
+   * リセット時の処理
+   */
+  useEffect(() => {
+    if (isReset) {
+      setIsMonitoring(false);
+      setIsAlarmActive(false);
+    }
+  }, [isReset]);
+
+  /**
+   * 目標時間の監視
+   * 目標時間の指定分前から監視を開始
+   */
+  useEffect(() => {
+    const checkTime = setInterval(() => {
+      if (isReset) {
+        return;
+      }
+      const now = new Date();
+      const [hours, minutes] = targetTime.split(":").map(Number);
+      const target = new Date();
+      target.setHours(hours, minutes, 0, 0);
+
+      // 既に過ぎている場合は翌日に設定
+      if (target <= now) {
+        target.setDate(target.getDate() + 1);
+      }
+      const diffMin = (target.getTime() - now.getTime()) / (1000 * 60);
+
+      if (diffMin <= monitoringStartMinutes && diffMin > 0) {
+        setIsMonitoring(true);
+      } else {
+        setIsMonitoring(false);
+      }
+    }, 1000);
+
+    return () => clearInterval(checkTime);
+  }, [targetTime, isReset, monitoringStartMinutes]);
+
+  /**
+   * 加速度センサーによる寝返り検知
+   */
+  useEffect(() => {
+    if (!isMonitoring) return;
+
+    if (magnitude > threshold && !isAlarmActive) {
+      console.log(
+        `Alarm triggered: magnitude ${magnitude.toFixed(2)} > threshold ${threshold}`,
+      );
+      setIsAlarmActive(true);
+    }
+  }, [magnitude, isAlarmActive, isMonitoring, threshold]);
+
+  const value: AlarmMonitorContextType = {
+    isMonitoring,
+    isAlarmActive,
+    reset,
+    setTargetTime,
+    targetTime,
+    threshold,
+    setThreshold,
+    monitoringStartMinutes,
+    setMonitoringStartMinutes,
+  };
+
+  return (
+    <AlarmMonitorContext.Provider value={value}>
+      {children}
+    </AlarmMonitorContext.Provider>
+  );
+};


### PR DESCRIPTION
close #46
設定画面からアラームの設定を変えられるようにしました

- 設定画面でアラームの設定を変更
- デモ画面で変更が適用されている、開始時間と加速度の閾値 

ボタンのアタリ判定が結構、小さくなっています。
もし小さすぎてUX悪い思ったら言うてください。なんとかするかもです